### PR TITLE
ubidy-messagequeueapi to 0.1.46

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -57,4 +57,4 @@ dependencies:
   version: 0.1.44
 - name: ubidy-messagequeueapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.45
+  version: 0.1.46


### PR DESCRIPTION
Promote ubidy-messagequeueapi to version 0.1.46