### PR TITLE
ubidy-messagequeueapi to 0.1.49

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -57,7 +57,7 @@ dependencies:
   version: 0.1.46
 - name: ubidy-messagequeueapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.47
+  version: 0.1.49
 - name: ubidy-messengerapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.25


### PR DESCRIPTION
Promote ubidy-messagequeueapi to version 0.1.49